### PR TITLE
fetch cache fix

### DIFF
--- a/pages/news/[id].vue
+++ b/pages/news/[id].vue
@@ -12,5 +12,5 @@ const config = useRuntimeConfig();
 const { data: response } = await useFetch(`/rcms-api/1/newsdetail/${route.params.id}`,{
   baseURL:config.public.apiBase,
   credentials: 'include',
-});
+}, route.params.id);
 </script>


### PR DESCRIPTION
news details page caches the detail response. Fixed by giving an id to useFetch()